### PR TITLE
Fix permission issues with generated hello_tokumei app.

### DIFF
--- a/embark/.gitignore
+++ b/embark/.gitignore
@@ -18,5 +18,3 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-
-hello_tokumei/

--- a/embark/.gitignore
+++ b/embark/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+hello_tokumei/

--- a/embark/Dockerfile
+++ b/embark/Dockerfile
@@ -1,13 +1,15 @@
 FROM elixir:1.5.1
 
-# Important!  Update this no-op ENV variable when this Dockerfile
-# is updated with the current date. It will force refresh of all
-# of the base images and things like `apt-get update` won't be using
-# old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2017-09-02
+ARG CONTAINER_USER='elixir'
 
-COPY . /installer/
-WORKDIR /installer
+RUN useradd -m -u 1000 -s /usr/bin/bash "${CONTAINER_USER}"
+
+USER "${CONTAINER_USER}"
+
+WORKDIR /home/"${CONTAINER_USER}"
+
+COPY . /home/"${CONTAINER_USER}"
+
 RUN mix compile && mix archive.build && mix archive.install --force
 
 WORKDIR /tmp

--- a/embark/README.md
+++ b/embark/README.md
@@ -10,10 +10,8 @@ docker run -v $(pwd):/tmp tokumei/embark hello_tokumei
 
 Steps to push a new image to docker hub.
 
-*Make sure date in dockerfile is updated.*
-
 ```
-docker build . -t tokumei/embark
+docker build --force-rm --no-cache --pull . -t tokumei/embark
 docker tag tokumei/embark tokumei/embark[:<tag>]
 docker push tokumei/embark
 ```

--- a/embark/lib/templates/Dockerfile
+++ b/embark/lib/templates/Dockerfile
@@ -1,21 +1,15 @@
 FROM elixir:1.5.1
 
-# Important!  Update this no-op ENV variable when this Dockerfile
-# is updated with the current date. It will force refresh of all
-# of the base images and things like `apt-get update` won't be using
-# old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2017-09-02
-
 RUN apt-get update && apt-get install -y inotify-tools
 
+ARG CONTAINER_USER='elixir'
+
+ARG APP_DIR=/home/"${CONTAINER_USER}"/app
+
+RUN useradd -m -u 1000 -s /usr/bin/bash "${CONTAINER_USER}"
+
+USER "${CONTAINER_USER}"
+
+WORKDIR "${APP_DIR}"
+
 RUN mix local.hex --force && mix local.rebar --force
-
-COPY mix.* /app/
-COPY config /app/config
-RUN cd /app && mix deps.get && mix deps.compile
-
-COPY . /app
-
-WORKDIR /app
-
-CMD iex -S mix

--- a/embark/lib/templates/docker-compose.yml.eex
+++ b/embark/lib/templates/docker-compose.yml.eex
@@ -1,6 +1,5 @@
 version: '2'
 
-# Add commented out loadbalancer and instructions to remove ports for scaling
 services:
   web:
     build:
@@ -14,5 +13,5 @@ services:
       - 8443:8443
       - 4001:4001
     volumes:
-      - .:/app
+      - .:/home/elixir/app
     command: sh start.sh


### PR DESCRIPTION
Fixes #38 

No need to use time stamps in Docker files, just use `docker build` options to force rebuild it with new base images. 